### PR TITLE
remove base image reassignment in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install --upgrade pip wheel
 
 # --- Final Stage ---
 # Use an official Python runtime as a base image
-FROM python:3.11-slim-bullseye as final
+From builder as final
 
 # Set the environment variables
 ENV FLASK_APP=app/__init__.py


### PR DESCRIPTION
```
FROM python:3.11-slim-bullseye as final
```
Would establish `python:3.11-slim-bullseye` as the image for everything below line 18. Causing certain build dependencies to be missing during `pip install` phase.
```
FROM builder as final
```
Allows for the use of the previously assigned builder image. There is also an option to remove this line all together.